### PR TITLE
✨[FEAT] #18: 일기 조회 api 구현 및 일기 작성과 수정 시 dto에 diaryDate항목 추가

### DIFF
--- a/genieary/src/main/java/com/hongik/genieary/common/swagger/DiaryAlreadyExists.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/swagger/DiaryAlreadyExists.java
@@ -1,0 +1,29 @@
+package com.hongik.genieary.common.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "4002",
+                description = "존재하지 않는 일기를 요청했을 때 발생하는 에러입니다.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = com.hongik.genieary.common.response.ApiResponse.class),
+                        examples = @ExampleObject(
+                                name = "DiaryNotFound",
+                                summary = "존재하지 않는 일기",
+                                value = SwaggerExamples.DIARY_NOT_FOUND_ERROR
+                        )
+                )
+        )
+})
+public @interface DiaryAlreadyExists {}

--- a/genieary/src/main/java/com/hongik/genieary/common/swagger/SuccessDiaryResponse.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/swagger/SuccessDiaryResponse.java
@@ -1,0 +1,44 @@
+package com.hongik.genieary.common.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+@Target({METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공 응답",
+        content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples = @ExampleObject(
+                        name = "onSuccess",
+                        summary = "기본 성공 응답",
+                        value = """
+                    {
+                      "isSuccess": true,
+                      "code": "COMMON200",
+                      "message": "성공입니다.",
+                      "result": {
+                                      "diaryId": 10,
+                                      "content": "오늘 날씨 쥑인다.",
+                                      "createdAt": "2025-06-15",
+                                      "isLiked": false,
+                                      "diaryDate": "2025-06-20"
+                                    }
+                    }
+                    """
+                )
+        )
+)
+public @interface SuccessDiaryResponse {}

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/controller/DiaryController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/controller/DiaryController.java
@@ -3,8 +3,10 @@ package com.hongik.genieary.domain.diary.controller;
 import com.hongik.genieary.auth.dto.request.SignupRequest;
 import com.hongik.genieary.auth.service.CustomUserDetails;
 import com.hongik.genieary.common.status.SuccessStatus;
+import com.hongik.genieary.common.swagger.DiaryAlreadyExists;
 import com.hongik.genieary.common.swagger.DiaryNotFoundApiResponse;
 import com.hongik.genieary.common.swagger.SuccessApiResponse;
+import com.hongik.genieary.common.swagger.SuccessDiaryResponse;
 import com.hongik.genieary.domain.diary.dto.DiaryRequestDto;
 import com.hongik.genieary.domain.diary.dto.DiaryResponseDto;
 import com.hongik.genieary.domain.diary.service.DiaryService;
@@ -35,47 +37,20 @@ public class DiaryController{
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     content = @Content(
-                            schema = @Schema(implementation = SignupRequest.class),
+                            schema = @Schema(implementation = DiaryRequestDto.DiaryCreateDto.class),
                             examples = @ExampleObject(
                                     name = "일기 예시",
-                                    value = "{\"content\": \"오늘 날씨 쥑인다.\", \"isLiked\": \"false\" }"
+                                    value = "{\"content\": \"오늘 날씨 쥑인다.\", \"isLiked\": \"false\", \"diaryDate\": \"2025-06-13\"  }"
                             )
                     )
-            ),
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "COMMON200",
-                            description = "일기 생성 성공했을 경우 나오는 응답입니다.",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = DiaryResponseDto.DiaryResultDto.class)
-                            )
-                    ),
-
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "DIARY4001",
-                            description = "해당하는 날짜에 일기가 이미 존재하는 경우 나오는 응답입니다.",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    examples = @ExampleObject(
-                                            name = "DIARY_DAY_ALREADY_EXISTS",
-                                            summary = "해당하는 날짜에 일기 이미 존재",
-                                            value = """
-                                                    {
-                                                      "isSuccess": false,
-                                                      "code": "DIARY4001",
-                                                      "message": "해당 날짜에 일기가 이미 존재합니다. 수정API를 사용해주세요."
-                                                    }
-                                                    """
-                                    )
-                            )
-                    )
-            }
+            )
     )
     @PostMapping
     @PreAuthorize("isAuthenticated()")
+    @SuccessDiaryResponse
+    @DiaryAlreadyExists
     public ResponseEntity<ApiResponse> createDiary(@AuthenticationPrincipal CustomUserDetails user,
-                                                   @Valid @RequestBody DiaryRequestDto.CreateDto requestDto) {
+                                                   @Valid @RequestBody DiaryRequestDto.DiaryCreateDto requestDto) {
         DiaryResponseDto.DiaryResultDto response = diaryService.createDiary(user, requestDto);
 
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
@@ -87,23 +62,21 @@ public class DiaryController{
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
                     content = @Content(
-                            schema = @Schema(implementation = DiaryRequestDto.UpdateDto.class),
+                            schema = @Schema(implementation = DiaryRequestDto.DiaryUpdateDto.class),
                             examples = @ExampleObject(
                                     name = "일기 수정 예시",
                                     value = "{\"content\": \"수정된 내용입니다.\", \"isLiked\": true }"
                             )
                     )
-            ),
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "일기 수정 성공"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4002", description = "존재하지 않는 일기")
-            }
+            )
     )
     @PatchMapping("/{diaryId}")
     @PreAuthorize("isAuthenticated()")
+    @SuccessDiaryResponse
+    @DiaryNotFoundApiResponse
     public ResponseEntity<ApiResponse> updateDiary(@PathVariable Long diaryId,
                                                    @AuthenticationPrincipal CustomUserDetails user,
-                                                   @Valid @RequestBody DiaryRequestDto.UpdateDto requestDto) {
+                                                   @Valid @RequestBody DiaryRequestDto.DiaryUpdateDto requestDto) {
 
         DiaryResponseDto.DiaryResultDto response = diaryService.updateDiary(diaryId, user.getUser(), requestDto);
 
@@ -119,6 +92,18 @@ public class DiaryController{
                                                    @PathVariable Long diaryId) {
         diaryService.deleteDiary(user.getUser(), diaryId);
         return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+    @GetMapping("/{diaryId}")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "일기 조회", description = "일기 ID에 해당하는 일기를 조회합니다.")
+    @SuccessApiResponse
+    @DiaryNotFoundApiResponse
+    public ResponseEntity<ApiResponse> getDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long diaryId) {
+        DiaryResponseDto.DiaryResultDto response = diaryService.getDiary(diaryId, userDetails.getUser());
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/converter/DiaryConverter.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/converter/DiaryConverter.java
@@ -9,12 +9,13 @@ import com.hongik.genieary.domain.user.entity.User;
 
 public class DiaryConverter {
 
-    public static Diary toEntity(User user, Calendar calendar, DiaryRequestDto.CreateDto dto) {
+    public static Diary toEntity(User user, Calendar calendar, DiaryRequestDto.DiaryCreateDto dto) {
         return Diary.builder()
                 .user(user)
                 .calendar(calendar)
                 .content(dto.getContent())
                 .isLiked(dto.getIsLiked() != null ? dto.getIsLiked() : false)
+                .diaryDate(dto.getDiaryDate())
                 .build();
     }
 
@@ -24,6 +25,7 @@ public class DiaryConverter {
                 .content(diary.getContent())
                 .createdAt(diary.getCreatedAt())
                 .isLiked(diary.getIsLiked())
+                .diaryDate(diary.getDiaryDate())
                 .build();
     }
 

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/dto/DiaryRequestDto.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/dto/DiaryRequestDto.java
@@ -4,20 +4,23 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 public class DiaryRequestDto {
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreateDto {
+    public static class DiaryCreateDto {
         private String content;
         private Boolean isLiked;
+        private LocalDate diaryDate;
     }
 
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UpdateDto {
+    public static class DiaryUpdateDto {
         private String content;
         private Boolean isLiked;
     }

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/dto/DiaryResponseDto.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/dto/DiaryResponseDto.java
@@ -15,5 +15,6 @@ public class DiaryResponseDto {
         private String content;
         private LocalDate createdAt;
         private Boolean isLiked;
+        private LocalDate diaryDate;
     }
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/entity/Diary.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/entity/Diary.java
@@ -6,6 +6,7 @@ import com.hongik.genieary.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 
 
 @Entity
@@ -33,6 +34,8 @@ public class Diary extends BaseEntity{
     @Column(name = "isLiked")
     private Boolean isLiked;
 
+    @Column(name = "diaryDate")
+    private LocalDate diaryDate;
 
     public void update(String content, Boolean isLiked) {
         if (content != null) this.content = content;

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/repository/DiaryRepository.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/repository/DiaryRepository.java
@@ -10,6 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    boolean existsByUserAndCreatedAt(User user, LocalDate createdAt);
+    boolean existsByUserAndDiaryDate(User user, LocalDate diaryDate);
     Optional<Diary> findByDiaryIdAndUser(Long id, User user);
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/service/DiaryService.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/service/DiaryService.java
@@ -7,8 +7,8 @@ import com.hongik.genieary.domain.user.entity.User;
 
 public interface DiaryService {
 
-    DiaryResponseDto.DiaryResultDto createDiary(CustomUserDetails user, DiaryRequestDto.CreateDto requestDto);
-    DiaryResponseDto.DiaryResultDto updateDiary(Long diaryId, User user, DiaryRequestDto.UpdateDto dto);
+    DiaryResponseDto.DiaryResultDto createDiary(CustomUserDetails user, DiaryRequestDto.DiaryCreateDto requestDto);
+    DiaryResponseDto.DiaryResultDto updateDiary(Long diaryId, User user, DiaryRequestDto.DiaryUpdateDto dto);
     void deleteDiary(User user, Long diaryId);
-
+    DiaryResponseDto.DiaryResultDto getDiary(Long diaryId, User user);
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/diary/service/DiaryServiceImpl.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/diary/service/DiaryServiceImpl.java
@@ -28,12 +28,12 @@ public class DiaryServiceImpl implements DiaryService{
 
     @Override
     @Transactional
-    public DiaryResponseDto.DiaryResultDto createDiary(CustomUserDetails userDetails, DiaryRequestDto.CreateDto requestDto) {
+    public DiaryResponseDto.DiaryResultDto createDiary(CustomUserDetails userDetails, DiaryRequestDto.DiaryCreateDto requestDto) {
 
         User user = userDetails.getUser();
-        LocalDate today = LocalDate.now();
-        int year = today.getYear();
-        int month = today.getMonthValue();
+        LocalDate diaryDate = requestDto.getDiaryDate();
+        int year = diaryDate.getYear();
+        int month = diaryDate.getMonthValue();
 
         Calendar calendar = calendarRepository.findByUserAndCreatedAtYearAndMonth(user, year, month)
                 .orElseGet(() -> calendarRepository.save(
@@ -43,7 +43,7 @@ public class DiaryServiceImpl implements DiaryService{
                                 .build()
                 ));
 
-        if (diaryRepository.existsByUserAndCreatedAt(user, today)) {
+        if (diaryRepository.existsByUserAndDiaryDate(user, diaryDate)) {
             throw new GeneralException(ErrorStatus.DIARY_DAY_ALREADY_EXISTS);
         }
 
@@ -55,7 +55,7 @@ public class DiaryServiceImpl implements DiaryService{
 
     @Override
     @Transactional
-    public DiaryResponseDto.DiaryResultDto updateDiary(Long diaryId, User user, DiaryRequestDto.UpdateDto dto) {
+    public DiaryResponseDto.DiaryResultDto updateDiary(Long diaryId, User user, DiaryRequestDto.DiaryUpdateDto dto) {
         Diary diary = diaryRepository.findByDiaryIdAndUser(diaryId, user)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.DIARY_NOT_FOUND));
 
@@ -71,6 +71,13 @@ public class DiaryServiceImpl implements DiaryService{
                 .orElseThrow(() -> new GeneralException(ErrorStatus.DIARY_NOT_FOUND));
 
         diaryRepository.delete(diary);
+    }
+
+    @Override
+    public DiaryResponseDto.DiaryResultDto getDiary(Long diaryId, User user) {
+        Diary diary = diaryRepository.findByDiaryIdAndUser(diaryId, user)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.DIARY_NOT_FOUND));
+        return DiaryConverter.toResponseDto(diary);
     }
 
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #18 

## 📝 작업 내용

> 일기 아이디로 조회하는 기능을 구현했습니다. 일기 작성과 수정 시에 diaryDate를 추가하여 일기의 날짜를 저장하도록 수정하였습니다.

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> diaryDate를 변경하면서 해당날짜에 일기가 잘 생성되는지 확인해주세요.