### PR TITLE
✨[FEAT] #24: 친구 검색 api 구현

### DIFF
--- a/genieary/src/main/java/com/hongik/genieary/common/status/ErrorStatus.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/status/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus {
     FRIEND_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "FRIEND4001", "이미 친구인 사용자입니다."),
     FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND4002", "친구 관계가 존재하지 않습니다."),
     FRIEND_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND4003", "상대 유저가 존재하지 않습니다."),
+    INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "FRIEND4004", "닉네임 검색어는 공백일 수 없습니다."),
 
     // FriendRequest
     FRIEND_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "FRIEND_REQUEST4001", "이미 친구 요청을 보냈습니다."),

--- a/genieary/src/main/java/com/hongik/genieary/common/swagger/FriendSearchSuccessApiResponse.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/swagger/FriendSearchSuccessApiResponse.java
@@ -1,0 +1,30 @@
+package com.hongik.genieary.common.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "200",
+                description = "닉네임 검색 결과를 성공적으로 반환합니다.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ApiResponse.class),
+                        examples = @ExampleObject(
+                                name = "FriendSearchSuccess",
+                                summary = "친구 검색 성공",
+                                value = SwaggerExamples.FRIEND_SEARCH_SUCCESS
+                        )
+                )
+        )
+})
+public @interface FriendSearchSuccessApiResponse {
+}

--- a/genieary/src/main/java/com/hongik/genieary/common/swagger/InvalidSearchKeywordApiResponse.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/swagger/InvalidSearchKeywordApiResponse.java
@@ -1,0 +1,30 @@
+package com.hongik.genieary.common.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+        @ApiResponse(
+                responseCode = "4004",
+                description = "검색어가 공백이거나 유효하지 않은 경우 발생하는 에러입니다.",
+                content = @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ApiResponse.class),
+                        examples = @ExampleObject(
+                                name = "InvalidSearchKeyword",
+                                summary = "공백 검색어",
+                                value = SwaggerExamples.INVALID_SEARCH_KEYWORD_ERROR
+                        )
+                )
+        )
+})
+public @interface InvalidSearchKeywordApiResponse {
+}

--- a/genieary/src/main/java/com/hongik/genieary/common/swagger/SwaggerExamples.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/swagger/SwaggerExamples.java
@@ -50,4 +50,43 @@ public class SwaggerExamples {
       "result": null
     }
     """;
+
+    public static final String INVALID_SEARCH_KEYWORD_ERROR = """
+    {
+        "isSuccess": false,
+            "code": "FRIEND4004",
+            "message": "닉네임 검색어는 공백일 수 없습니다.",
+            "pageInfo": null,
+            "result": null
+    }
+    """;
+
+    public static final String FRIEND_SEARCH_SUCCESS = """
+        {
+          "isSuccess": true,
+          "code": "COMMON200",
+          "message": "성공입니다.",
+          "pageInfo": {
+            "page": 0,
+            "size": 10,
+            "hasNext": true,
+            "totalElements": 19,
+            "totalPages": 2
+          },
+          "result": [
+            {
+              "friendId": 7,
+              "nickname": "채린",
+              "profileImage": null,
+              "email": "testt@example.com"
+            },
+            {
+              "friendId": 8,
+              "nickname": "채린1",
+              "profileImage": null,
+              "email": "test@example.com"
+            }
+          ]
+        }
+        """;
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/controller/FriendController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/controller/FriendController.java
@@ -4,7 +4,9 @@ import com.hongik.genieary.auth.service.CustomUserDetails;
 import com.hongik.genieary.common.response.ApiResponse;
 import com.hongik.genieary.common.status.SuccessStatus;
 import com.hongik.genieary.common.swagger.FriendNotFoundApiResponse;
+import com.hongik.genieary.common.swagger.FriendSearchSuccessApiResponse;
 import com.hongik.genieary.common.swagger.FriendUserNotFoundApiResponse;
+import com.hongik.genieary.common.swagger.InvalidSearchKeywordApiResponse;
 import com.hongik.genieary.domain.friend.dto.FriendResponseDto;
 import com.hongik.genieary.domain.friend.service.FriendService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,7 +69,8 @@ public class FriendController {
     @GetMapping("/search")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "친구 검색", description = "닉네임에 해당하는 유저를 검색합니다.")
-    @FriendNotFoundApiResponse
+    @FriendSearchSuccessApiResponse
+    @InvalidSearchKeywordApiResponse
     public ResponseEntity<ApiResponse> searchFriends(
             @RequestParam String nickname,
             @ParameterObject @PageableDefault(size = 10, sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable) {

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/controller/FriendController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/controller/FriendController.java
@@ -72,9 +72,10 @@ public class FriendController {
     @FriendSearchSuccessApiResponse
     @InvalidSearchKeywordApiResponse
     public ResponseEntity<ApiResponse> searchFriends(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam String nickname,
             @ParameterObject @PageableDefault(size = 10, sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<FriendResponseDto.FriendSearchResultDto> resultPage = friendService.searchFriends(nickname, pageable);
+        Page<FriendResponseDto.FriendSearchResultDto> resultPage = friendService.searchFriends(userDetails.getUser(),nickname, pageable);
 
         return ApiResponse.onSuccess(SuccessStatus._OK, resultPage);
     }

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/controller/FriendController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/controller/FriendController.java
@@ -10,6 +10,11 @@ import com.hongik.genieary.domain.friend.service.FriendService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -57,5 +62,17 @@ public class FriendController {
 
         FriendResponseDto.FriendProfileDto profile = friendService.getFriendProfile(userDetails.getUser(), friendId);
         return ApiResponse.onSuccess(SuccessStatus._OK, profile);
+    }
+
+    @GetMapping("/search")
+    @PreAuthorize("isAuthenticated()")
+    @Operation(summary = "친구 검색", description = "닉네임에 해당하는 유저를 검색합니다.")
+    @FriendNotFoundApiResponse
+    public ResponseEntity<ApiResponse> searchFriends(
+            @RequestParam String nickname,
+            @ParameterObject @PageableDefault(size = 10, sort = "nickname", direction = Sort.Direction.ASC) Pageable pageable) {
+        Page<FriendResponseDto.FriendSearchResultDto> resultPage = friendService.searchFriends(nickname, pageable);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, resultPage);
     }
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/dto/FriendResponseDto.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/dto/FriendResponseDto.java
@@ -41,4 +41,15 @@ public class FriendResponseDto {
             private String imageUrl;
         }
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FriendSearchResultDto {
+        private Long friendId;
+        private String nickname;
+        private String profileImage;
+        private String email;
+    }
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/service/FriendService.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/service/FriendService.java
@@ -3,6 +3,8 @@ package com.hongik.genieary.domain.friend.service;
 
 import com.hongik.genieary.domain.friend.dto.FriendResponseDto;
 import com.hongik.genieary.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -11,4 +13,5 @@ public interface FriendService {
     List<FriendResponseDto.FriendListResultDto> getFriendList(User user);
     void deleteFriend(User user, Long friendId);
     FriendResponseDto.FriendProfileDto getFriendProfile(User requester, Long friendId);
+    Page<FriendResponseDto.FriendSearchResultDto> searchFriends(String nickname, Pageable pageable);
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/service/FriendService.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/service/FriendService.java
@@ -13,5 +13,5 @@ public interface FriendService {
     List<FriendResponseDto.FriendListResultDto> getFriendList(User user);
     void deleteFriend(User user, Long friendId);
     FriendResponseDto.FriendProfileDto getFriendProfile(User requester, Long friendId);
-    Page<FriendResponseDto.FriendSearchResultDto> searchFriends(String nickname, Pageable pageable);
+    Page<FriendResponseDto.FriendSearchResultDto> searchFriends(User requester, String nickname, Pageable pageable);
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/friend/service/FriendServiceImpl.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/friend/service/FriendServiceImpl.java
@@ -73,6 +73,11 @@ public class FriendServiceImpl implements FriendService {
 
     @Override
     public Page<FriendResponseDto.FriendSearchResultDto> searchFriends(String nickname, Pageable pageable) {
+
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new GeneralException(ErrorStatus.INVALID_SEARCH_KEYWORD);
+        }
+
         Page<User> friendsPage = userRepository.findByNicknameContaining(nickname, pageable);
         return friendsPage.map(friend ->
                 FriendResponseDto.FriendSearchResultDto.builder()

--- a/genieary/src/main/java/com/hongik/genieary/domain/user/repository/UserRepository.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/user/repository/UserRepository.java
@@ -1,12 +1,18 @@
 package com.hongik.genieary.domain.user.repository;
 
 import com.hongik.genieary.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
-
     boolean existsByEmail(String email);
+
+    @Query("SELECT u FROM User u WHERE u.nickname LIKE %:nickname% ORDER BY CASE WHEN u.nickname = :nickname THEN 0 ELSE 1 END, u.nickname ASC")
+    Page<User> findByNicknameContaining(@Param("nickname")String nickname, Pageable pageable);
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #24 

## 📝 작업 내용

> 닉네임으로 친구를 검색하는 기능을 구현했습니다. param값과 일치하는 닉네임을 먼저 반환하도록 구현하였고, param값을 포함하고 있는 경우는 오름차순으로 정렬하여 반환하였습니다. page 기본값은 0이고, size 기본값은 10, 정렬 기본값은 nickname 오름차순입니다. 프론트에서 페이지 넘버링 0부터 하시면 감사하겠습니다.

### 📸 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> "채린"검색했을 때 "채린"이 먼저 나오는지, "채" 검색했을 때 아래 항목들 다 나오는지, 나머지들 정렬 잘 되는지 등등 확인해주세용

> page에 0넣으면 첫번째 페이지 나오고, 1넣으면 두번째 페이지 나옵니당

> sql쿼리로 아래 더미데이터 넣고 확인해주세요!  
  INSERT INTO user (email, password, nickname) VALUES
  ('chaelin1@example.com', 'password1', '채린1'),
  ('chaelin2@example.com', 'password2', '채린2'),
  ('chaelin3@example.com', 'password3', '채린3'),
  ('chaelin4@example.com', 'password4', '채린4'),
  ('chaelin5@example.com', 'password5', '채린5'),
  ('chaelinkim@example.com', 'password', '김채린'),
('chaelin@example.com', 'password', '채린');


