### PR TITLE
✨ [FEAT] #78: 저장된 선물 목록 조회 기능 구현

### DIFF
--- a/genieary/src/main/java/com/hongik/genieary/domain/recommend/controller/RecommendController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/recommend/controller/RecommendController.java
@@ -12,7 +12,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -134,5 +136,20 @@ public class RecommendController {
         List<RecommendResponseDto.GiftResultDto> gifts = recommendService.getRecommendGifts(userId, date);
 
         return ApiResponse.onSuccess(SuccessStatus._OK, gifts);
+    }
+
+    @Operation(
+            summary = "저장된 선물 목록 조회",
+            description = "좋아요를 누른 모든 추천 선물(공개/비공개 포함)을 조회합니다."
+    )
+    @GetMapping("/like")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> getMyLikedRecommendations(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Page<RecommendResponseDto.LikeListDto> data = recommendService.getMyLikedRecommendations(userId, page, size);
+        return ApiResponse.onSuccess(SuccessStatus._OK, data);
     }
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/recommend/dto/RecommendResponseDto.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/recommend/dto/RecommendResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 public class RecommendResponseDto {
 
     @Getter
@@ -66,5 +68,18 @@ public class RecommendResponseDto {
         private boolean isLiked;
         private boolean isHated;
 
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LikeListDto {
+        private Long recommendId;
+        private String name;
+        private String imageUrl;
+        private String description;
+        private LocalDate updatedAt;
+        private boolean isPublic;
     }
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/recommend/repository/RecommendRepository.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/recommend/repository/RecommendRepository.java
@@ -15,5 +15,6 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
     Optional<Recommend> findByRecommendIdAndUser(Long recommendId, User user);
     List<Recommend> findTop3ByUserIdAndCreatedAtOrderByRecommendIdDesc(Long userId, LocalDate createdAt);
     Page<Recommend> findByUser_IdAndIsLikedTrueAndIsPublicTrue(Long friendId, Pageable pageable);
+    Page<Recommend> findByUser_IdAndIsLikedTrue(Long userId, Pageable pageable);
 }
 

--- a/genieary/src/main/java/com/hongik/genieary/domain/recommend/service/RecommendService.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/recommend/service/RecommendService.java
@@ -2,6 +2,7 @@ package com.hongik.genieary.domain.recommend.service;
 
 import com.hongik.genieary.domain.recommend.Category;
 import com.hongik.genieary.domain.recommend.dto.RecommendResponseDto;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,4 +18,5 @@ public interface RecommendService {
 
     List<RecommendResponseDto.GiftResultDto> getRecommendGifts(Long userId, LocalDate date);
 
+    Page<RecommendResponseDto.LikeListDto> getMyLikedRecommendations(Long userId, int page, int size);
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/recommend/service/RecommendServiceImpl.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/recommend/service/RecommendServiceImpl.java
@@ -14,6 +14,10 @@ import com.hongik.genieary.domain.user.repository.InterestRepository;
 import com.hongik.genieary.domain.user.repository.UserInterestRepository;
 import com.hongik.genieary.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -175,5 +179,23 @@ public class RecommendServiceImpl implements RecommendService{
                         .isHated(recommend.isHated())
                         .build())
                 .toList();
+    }
+
+    @Override
+    public Page<RecommendResponseDto.LikeListDto> getMyLikedRecommendations(Long userId, int page, int size) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updatedAt"));
+        Page<Recommend> likedPage = recommendRepository.findByUser_IdAndIsLikedTrue(user.getId(), pageable);
+
+        return likedPage.map(r -> RecommendResponseDto.LikeListDto.builder()
+                .recommendId(r.getRecommendId())
+                .name(r.getContentName())
+                .imageUrl(r.getContentImage())
+                .description(r.getContentDescription())
+                .updatedAt(r.getUpdatedAt())
+                .isPublic(r.isPublic())
+                .build());
     }
 }


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - close #78 
2. **📝 작업 내용**
    - 유저 본인이 좋아요한 선물 목록을 조회하는 기능입니다. (공개/비공개 모두 포함)
3. **📸 스크린샷 (선택)**
<img width="1033" height="679" alt="스크린샷 2025-10-19 오후 2 23 03" src="https://github.com/user-attachments/assets/33d7ddd5-e33e-4e2c-876b-83c552396da9" />

4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 예: "메서드 XXX의 이름을 더 명확히 하고 싶은데, 좋은 아이디어가 있으신가요?"
