### PR TITLE
✨ [FEAT] #80: 얼굴 사진을 통한 감정 분석 기능 구현

### DIFF
--- a/genieary/src/main/java/com/hongik/genieary/common/swagger/ParseErrorApiResponse.java
+++ b/genieary/src/main/java/com/hongik/genieary/common/swagger/ParseErrorApiResponse.java
@@ -19,11 +19,11 @@ import java.lang.annotation.*;
                         mediaType = "application/json",
                         schema = @Schema(implementation = com.hongik.genieary.common.response.ApiResponse.class),
                         examples = @ExampleObject(
-                                name = "RecommendParseError",
+                                name = "ParseError",
                                 summary = "Json 응답 parse 실패",
                                 value = SwaggerExamples.JSON_PARSE_ERROR
                         )
                 )
         )
 })
-public @interface RecommendParseErrorApiResponse {}
+public @interface ParseErrorApiResponse {}

--- a/genieary/src/main/java/com/hongik/genieary/domain/ai/controller/FastApiController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/ai/controller/FastApiController.java
@@ -1,0 +1,50 @@
+package com.hongik.genieary.domain.ai.controller;
+
+import com.hongik.genieary.common.response.ApiResponse;
+import com.hongik.genieary.common.status.SuccessStatus;
+import com.hongik.genieary.common.swagger.ParseErrorApiResponse;
+import com.hongik.genieary.domain.ai.dto.FastApiResponseDto;
+import com.hongik.genieary.domain.ai.service.FastApiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ai")
+@Tag(name = "FastAPI", description = "fastapi 관련 API")
+public class FastApiController {
+
+    private final FastApiService fastApiService;
+
+    @PostMapping(value = "/face-analysis")
+    @Operation(
+            summary = "얼굴사진과 다이어리기반 감정분석",
+            description = "사용자의 얼굴 사진 링크 기반으로 감정을 분석해줍니다. 사용자가 선택한 날짜에 일기가 있을 경우 일기내용을 고려하여 분석해줍니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = FastApiResponseDto.FaceAnalysisResponseDto.class)
+            )
+    )
+    @ParseErrorApiResponse
+    public ResponseEntity<ApiResponse> analyzeFace(@AuthenticationPrincipal(expression = "id") Long userId,
+                                                   LocalDate diaryDate,
+                                                   String faceImg){
+
+        FastApiResponseDto.FaceAnalysisResponseDto dto = fastApiService.analyzeFace(userId, diaryDate, faceImg);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, dto);
+    }
+}
+

--- a/genieary/src/main/java/com/hongik/genieary/domain/ai/dto/FastApiResponseDto.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/ai/dto/FastApiResponseDto.java
@@ -1,0 +1,33 @@
+package com.hongik.genieary.domain.ai.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+public class FastApiResponseDto {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class FaceEmotionResponseDto {
+        private String predictedEmotion;
+        private Map<String, String> allPredictions;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FaceAnalysisResponseDto {
+        private String predictedEmotion;
+        private Map<String, String> allPredictions;
+        private String analysis;
+    }
+}

--- a/genieary/src/main/java/com/hongik/genieary/domain/ai/service/FastApiService.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/ai/service/FastApiService.java
@@ -1,0 +1,31 @@
+package com.hongik.genieary.domain.ai.service;
+
+import com.hongik.genieary.domain.ai.dto.FastApiResponseDto;
+import com.hongik.genieary.domain.diary.entity.Diary;
+import com.hongik.genieary.domain.diary.repository.DiaryRepository;
+import com.hongik.genieary.infra.fastapi.FastApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class FastApiService {
+
+    private final FastApiClient fastApiClient;
+    private final OpenAiService openAiService;
+    private final DiaryRepository diaryRepository;
+
+    public FastApiResponseDto.FaceAnalysisResponseDto analyzeFace(Long userId, LocalDate diaryDate, String faceImg) {
+        FastApiResponseDto.FaceEmotionResponseDto dto = fastApiClient.analyzeFace(faceImg);
+
+        String diaryContent = diaryRepository.findByUserIdAndDiaryDate(userId, diaryDate)
+                .map(Diary::getContent)
+                .orElse(null);
+
+        FastApiResponseDto.FaceAnalysisResponseDto result = openAiService.getFaceAnalysis(faceImg, dto.getPredictedEmotion(), dto.getAllPredictions(), diaryContent);
+
+        return result;
+    }
+}

--- a/genieary/src/main/java/com/hongik/genieary/domain/ai/service/OpenAiService.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/ai/service/OpenAiService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hongik.genieary.common.exception.GeneralException;
 import com.hongik.genieary.common.status.ErrorStatus;
 import com.hongik.genieary.common.util.PromptLoader;
+import com.hongik.genieary.domain.ai.dto.FastApiResponseDto;
 import com.hongik.genieary.domain.recommend.Category;
 import com.hongik.genieary.domain.recommend.dto.RecommendResponseDto;
 import com.hongik.genieary.infra.openai.OpenAiClient;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -55,5 +58,36 @@ public class OpenAiService {
             throw new GeneralException(ErrorStatus.JSON_PARSE_ERROR);
         }
 
+    }
+
+    public FastApiResponseDto.FaceAnalysisResponseDto getFaceAnalysis(String faceImg, String predictedEmotion, Map<String, String> allPredictions, String diaryContent) {
+
+        String template = promptLoader.loadPrompt("analyze_face_prompt.txt");
+
+        String readablePredictions = allPredictions.entrySet().stream()
+                .map(e -> e.getKey() + ": " + e.getValue() + "%")
+                .collect(Collectors.joining(", "));
+
+        if (diaryContent == null || diaryContent.isBlank()) {
+            diaryContent = "No diary content was provided. Please analyze only based on the emotion data.";
+        }
+
+        String prompt = template
+                .replace("{faceImgUrl}", faceImg)
+                .replace("{predictedEmotion}", predictedEmotion)
+                .replace("{allPredictions}", readablePredictions)
+                .replace("{diaryContent}", diaryContent);
+
+        String response = openAiClient.requestChatCompletion(prompt);
+
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(
+                    response,
+                    new TypeReference<FastApiResponseDto.FaceAnalysisResponseDto>() {}
+            );
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorStatus.JSON_PARSE_ERROR);
+        }
     }
 }

--- a/genieary/src/main/java/com/hongik/genieary/domain/recommend/controller/RecommendController.java
+++ b/genieary/src/main/java/com/hongik/genieary/domain/recommend/controller/RecommendController.java
@@ -38,7 +38,7 @@ public class RecommendController {
             )
     )
     @PostMapping
-    @RecommendParseErrorApiResponse
+    @ParseErrorApiResponse
     public ResponseEntity<ApiResponse> recommendGifts(
             @AuthenticationPrincipal(expression = "id") Long userId,
             @RequestParam Category category,

--- a/genieary/src/main/java/com/hongik/genieary/infra/fastapi/FastApiClient.java
+++ b/genieary/src/main/java/com/hongik/genieary/infra/fastapi/FastApiClient.java
@@ -1,0 +1,47 @@
+package com.hongik.genieary.infra.fastapi;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hongik.genieary.common.exception.GeneralException;
+import com.hongik.genieary.common.status.ErrorStatus;
+import com.hongik.genieary.domain.ai.dto.FastApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class FastApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${fastapi.base-url}")
+    private String fastApiBaseUrl;
+
+    public FastApiResponseDto.FaceEmotionResponseDto analyzeFace(String faceImg) {
+        String url = fastApiBaseUrl + "/analyze/url";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("image_url", faceImg);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+
+        try {
+            return objectMapper.readValue(response.getBody(), FastApiResponseDto.FaceEmotionResponseDto.class);
+        } catch (JsonProcessingException e) {
+            throw new GeneralException(ErrorStatus.JSON_PARSE_ERROR);
+        }
+    }
+}

--- a/genieary/src/main/resources/application.yml
+++ b/genieary/src/main/resources/application.yml
@@ -43,6 +43,9 @@ google:
     api-key: ${GOOGLE_API_KEY}
     cx: ${GOOGLE_CX_ID}
 
+fastapi:
+  base-url: ${FASTAPI_BASE_URL}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
1. **#⃣ 연관된 이슈**
    - 관련 이슈를 명시해주세요.
    - close #80 
2. **📝 작업 내용**
    - 다이어리 날짜와 얼굴 사진 링크를 포함하여 요청하면 fastAPI와 openAI를 통해 얼굴 분석을 반환하게 했습니다.
3. **📸 스크린샷 (선택)**
    - 작업 내용을 시각적으로 표현할 스크린샷을 포함하세요.
4. **💬 리뷰 요구사항 (선택)**
    - 리뷰어가 특히 검토해주었으면 하는 부분이 있다면 작성해주세요.
    - 노션에서 환경변수 추가해주세용
    - 얼굴 사진 링크는 프론트에서 사진찍은 후에 s3통해서 요청값에 넣어주는 걸로 알고 있는데, 관련하여 다른 링크가 들어왔을 때 에러처리를 해주는 게 좋을지 의문입니당
